### PR TITLE
Updated BeautifulSoup code to include lxml’s HTML parser

### DIFF
--- a/theoatmeal.py
+++ b/theoatmeal.py
@@ -25,7 +25,7 @@ for url_range in range(1,15):
     main_url_opener = urllib.urlopen(main_url)
     main_url_response = main_url_opener.read()
 
-    main_url_soup = BeautifulSoup(main_url_response)
+    main_url_soup = BeautifulSoup(main_url_response,"lxml")
     mylist = []
     for comiclink in main_url_soup.find_all('a'):
         all_links = comiclink.get('href')
@@ -48,7 +48,7 @@ for url_range in range(1,15):
         opener = urllib.urlopen(url)
         response = opener.read()
 
-        soupedversion = BeautifulSoup(response)
+        soupedversion = BeautifulSoup(response,"lxml")
 
         comicname = soupedversion.title.string
         comicname = comicname.replace('?','')


### PR DESCRIPTION
Updated BeautifulSoup code to include lxml’s HTML parser as the old way
of invoking beautifulsoup is no longer used.
If you’re using a version of Python 2 earlier than 2.7.3, or a version of Python 3 earlier than 3.2.2, it’s essential that you install lxml or html5lib–Python’s built-in HTML parser is just not very good in older versions.
